### PR TITLE
Shorten bubble layout and compact stretch timer UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
             grid-template-columns: repeat(4, 1fr);
             grid-template-rows: repeat(3, 1fr);
             gap: 20px;
-            min-height: 600px;
+            min-height: 480px;
         }
 
         .bubble {
@@ -187,7 +187,7 @@
             box-shadow: 0 10px 40px rgba(41, 161, 196, 0.35);
             justify-content: flex-start;
             align-items: stretch;
-            padding: 18px 18px 56px;
+            padding: 14px 14px 46px;
         }
 
         .bubble.stretch-bubble:hover:not(.dragging) {
@@ -198,40 +198,40 @@
         .stretch-timer {
             display: flex;
             flex-direction: column;
-            gap: 14px;
+            gap: 10px;
             width: 100%;
             color: #f7fafc;
-            padding-bottom: 16px;
+            padding-bottom: 8px;
         }
 
         .stretch-header {
             display: flex;
             flex-direction: column;
-            gap: 2px;
+            gap: 1px;
         }
 
         .stretch-title {
-            font-size: 1.1rem;
+            font-size: 1rem;
             font-weight: 600;
             letter-spacing: 0.5px;
         }
 
         .stretch-description {
-            font-size: 0.75rem;
+            font-size: 0.7rem;
             opacity: 0.8;
         }
 
         .stretch-inputs {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-            gap: 10px;
+            grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+            gap: 8px;
         }
 
         .stretch-field {
             display: flex;
             flex-direction: column;
-            gap: 4px;
-            font-size: 0.75rem;
+            gap: 3px;
+            font-size: 0.72rem;
             text-transform: uppercase;
             letter-spacing: 0.5px;
         }
@@ -245,8 +245,8 @@
             width: 100%;
             border: none;
             border-radius: 10px;
-            padding: 8px;
-            font-size: 0.9rem;
+            padding: 6px;
+            font-size: 0.85rem;
             font-weight: 600;
             color: #1a202c;
             background: rgba(255, 255, 255, 0.92);
@@ -260,13 +260,13 @@
         .stretch-timeline {
             display: flex;
             flex-direction: column;
-            gap: 8px;
+            gap: 6px;
         }
 
         .stretch-timeline-line {
             position: relative;
             width: 100%;
-            height: 12px;
+            height: 9px;
             border-radius: 999px;
             background: rgba(255, 255, 255, 0.25);
             overflow: hidden;
@@ -276,8 +276,8 @@
         .stretch-timeline-pointer {
             position: absolute;
             top: 50%;
-            width: 14px;
-            height: 14px;
+            width: 12px;
+            height: 12px;
             border-radius: 50%;
             background: #ffffff;
             border: 2px solid rgba(31, 59, 115, 0.4);
@@ -287,10 +287,10 @@
         }
 
         .stretch-status {
-            font-size: 0.85rem;
+            font-size: 0.78rem;
             font-weight: 600;
             text-align: center;
-            padding: 8px 10px;
+            padding: 6px 8px;
             border-radius: 999px;
             background: rgba(15, 32, 60, 0.45);
             box-shadow: inset 0 1px 3px rgba(15, 23, 42, 0.3);
@@ -298,16 +298,16 @@
 
         .stretch-controls {
             display: flex;
-            gap: 10px;
+            gap: 8px;
         }
 
         .stretch-btn {
             flex: 1;
-            padding: 8px 0;
+            padding: 6px 0;
             border: none;
             border-radius: 999px;
             font-weight: 600;
-            font-size: 0.95rem;
+            font-size: 0.85rem;
             cursor: pointer;
             background: rgba(255, 255, 255, 0.92);
             color: #1a202c;


### PR DESCRIPTION
## Summary
- decrease the grid's minimum height so the bubbles occupy less vertical space
- tighten the stretch stopwatch layout to keep all controls readable in the shorter bubble

## Testing
- Manual QA: opened `index.html` in a browser

------
https://chatgpt.com/codex/tasks/task_e_68cd9c018b4c8333906579bb77992286