### PR TITLE
Adjust stretch stopwatch layout and unify white typography

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,12 +14,12 @@
         body {
             font-family: 'Arial', sans-serif;
             background: #2e2a2a;
-            background-image: 
+            background-image:
                 /* Horizontal lines */
                 linear-gradient(0deg, rgba(245, 245, 245, 0.1) 1px, transparent 1px),
                 /* Vertical lines */
                 linear-gradient(90deg, rgba(245, 245, 245, 0.1) 1px, transparent 1px);
-            background-size: 
+            background-size:
                 40px 40px,
                 40px 40px;
             min-height: 100vh;
@@ -27,6 +27,7 @@
             display: flex;
             justify-content: center;
             align-items: center;
+            color: #ffffff;
         }
 
         .container {
@@ -200,7 +201,7 @@
             flex-direction: column;
             gap: 10px;
             width: 100%;
-            color: #f7fafc;
+            color: #ffffff;
             padding-bottom: 8px;
         }
 
@@ -222,9 +223,10 @@
         }
 
         .stretch-inputs {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+            display: flex;
             gap: 8px;
+            width: 100%;
+            flex-wrap: nowrap;
         }
 
         .stretch-field {
@@ -234,23 +236,29 @@
             font-size: 0.72rem;
             text-transform: uppercase;
             letter-spacing: 0.5px;
+            flex: 1 1 0;
+            min-width: 0;
         }
 
         .stretch-field span {
             font-weight: 600;
-            color: rgba(255, 255, 255, 0.85);
+            color: #ffffff;
         }
 
         .stretch-field input {
             width: 100%;
-            border: none;
+            border: 1px solid rgba(255, 255, 255, 0.35);
             border-radius: 10px;
             padding: 6px;
             font-size: 0.85rem;
             font-weight: 600;
-            color: #1a202c;
-            background: rgba(255, 255, 255, 0.92);
+            color: #ffffff;
+            background: rgba(15, 32, 60, 0.6);
             box-shadow: inset 0 1px 3px rgba(15, 23, 42, 0.2);
+        }
+
+        .stretch-field input::placeholder {
+            color: rgba(255, 255, 255, 0.65);
         }
 
         .stretch-field input:focus {
@@ -304,13 +312,13 @@
         .stretch-btn {
             flex: 1;
             padding: 6px 0;
-            border: none;
+            border: 1px solid rgba(255, 255, 255, 0.35);
             border-radius: 999px;
             font-weight: 600;
             font-size: 0.85rem;
             cursor: pointer;
-            background: rgba(255, 255, 255, 0.92);
-            color: #1a202c;
+            background: rgba(15, 32, 60, 0.65);
+            color: #ffffff;
             box-shadow: 0 4px 12px rgba(15, 23, 42, 0.25);
             transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
         }
@@ -318,7 +326,7 @@
         .stretch-btn:hover {
             transform: translateY(-2px);
             box-shadow: 0 6px 14px rgba(15, 23, 42, 0.3);
-            background: #ffffff;
+            background: rgba(22, 46, 88, 0.75);
         }
 
         .stretch-btn:active {
@@ -356,6 +364,7 @@
             display: flex;
             flex-direction: column;
             gap: 12px;
+            color: #ffffff;
         }
 
         .converter-header {
@@ -370,7 +379,7 @@
         .converter-title {
             font-size: 1rem;
             font-weight: 600;
-            color: #4a5568;
+            color: #ffffff;
         }
 
         .swap-btn {
@@ -393,42 +402,49 @@
             display: flex;
             align-items: center;
             gap: 5px;
-            flex-wrap: wrap;
+            flex-wrap: nowrap;
+            width: 100%;
         }
 
         .input-group select {
             flex: 1;
             padding: 6px 8px;
-            border: 1px solid #cbd5e0;
+            border: 1px solid rgba(255, 255, 255, 0.35);
             border-radius: 4px;
             font-size: 0.9rem;
-            background: white;
+            background: rgba(17, 34, 68, 0.65);
+            color: #ffffff;
             cursor: pointer;
         }
 
         .input-group select:focus {
             outline: none;
-            border-color: #667eea;
+            border-color: rgba(255, 255, 255, 0.6);
         }
 
         .input-group input {
             flex: 1;
             padding: 6px 8px;
-            border: 1px solid #cbd5e0;
+            border: 1px solid rgba(255, 255, 255, 0.35);
             border-radius: 4px;
             font-size: 0.9rem;
-            background: white;
+            background: rgba(17, 34, 68, 0.65);
+            color: #ffffff;
+        }
+
+        .input-group input::placeholder {
+            color: rgba(255, 255, 255, 0.65);
         }
 
         .input-group input:focus {
             outline: none;
-            border-color: #667eea;
+            border-color: rgba(255, 255, 255, 0.6);
         }
 
         .input-label {
             font-size: 0.9rem;
             font-weight: 500;
-            color: #4a5568;
+            color: #ffffff;
             min-width: 15px;
         }
 
@@ -446,20 +462,20 @@
 
         .result-label {
             font-size: 0.8rem;
-            color: #718096;
+            color: #ffffff;
             font-weight: 500;
         }
 
         .result-value {
             font-size: 0.8rem;
             font-weight: 600;
-            color: #2d3748;
+            color: #ffffff;
         }
 
         .word {
             font-size: 1.2rem;
             font-weight: 600;
-            color: #70543E;
+            color: #ffffff;
             text-align: center;
             padding: 10px;
             text-transform: capitalize;
@@ -467,7 +483,7 @@
 
         .title {
             text-align: center;
-            color: #F5F5F5;
+            color: #ffffff;
             font-size: 3.5rem;
             font-weight: 700;
             font-family: 'Georgia', serif;
@@ -499,7 +515,11 @@
             }
 
             .stretch-inputs {
-                grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+                flex-wrap: wrap;
+            }
+
+            .input-group {
+                flex-wrap: wrap;
             }
 
             .title {
@@ -522,7 +542,12 @@
             }
 
             .stretch-inputs {
-                grid-template-columns: 1fr;
+                flex-direction: column;
+            }
+
+            .input-group {
+                flex-direction: column;
+                align-items: stretch;
             }
         }
     </style>
@@ -645,13 +670,13 @@
                     // Add hover effect for better UX
                     bubble.addEventListener('mouseenter', () => {
                         if (!bubble.classList.contains('dragging')) {
-                            wordElement.style.color = '#5D473A';
+                            wordElement.style.color = '#ffffff';
                         }
                     });
 
                     bubble.addEventListener('mouseleave', () => {
                         if (!bubble.classList.contains('dragging')) {
-                            wordElement.style.color = '#70543E';
+                            wordElement.style.color = '#ffffff';
                         }
                     });
                 }


### PR DESCRIPTION
## Summary
- collapse the stretch stopwatch inputs into a single-row flex layout to reduce the card height
- update converter input groups to share the tighter horizontal formatting and support responsive wrapping on smaller screens
- switch all textual elements to white typography with darkened input backgrounds for readability across the interface

## Testing
- Manual - Viewed index.html in the browser


------
https://chatgpt.com/codex/tasks/task_e_68cddd34e7f0833389fe69f0fa1ec70f