### PR TITLE
Adjust bubble layout for consistent sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,32 +31,36 @@
         }
 
         .container {
-            max-width: 1200px;
+            max-width: 1120px;
             width: 100%;
         }
 
         .grid {
             display: grid;
-            grid-template-columns: repeat(4, 1fr);
-            grid-template-rows: repeat(3, 1fr);
-            gap: 20px;
-            min-height: 480px;
+            grid-template-columns: repeat(4, minmax(0, 1fr));
+            gap: 18px;
+            width: 100%;
+            max-width: 960px;
+            margin: 0 auto;
         }
 
         .bubble {
             background: linear-gradient(145deg, #D9CBA3 0%, #B2B2B2 100%);
             border-radius: 25px;
             display: flex;
-            justify-content: center;
-            align-items: center;
+            flex-direction: column;
+            justify-content: flex-start;
+            align-items: stretch;
             cursor: pointer;
             transition: all 0.3s ease;
             box-shadow: 0 8px 32px rgba(43, 43, 43, 0.15);
             backdrop-filter: blur(10px);
             border: 1px solid #A89F91;
-            min-height: 120px;
             position: relative;
             user-select: none;
+            padding: 12px 12px 40px;
+            aspect-ratio: 1 / 1;
+            overflow: hidden;
         }
 
         .drag-handle {
@@ -186,9 +190,7 @@
             background: linear-gradient(145deg, #1f3b73 0%, #29a1c4 100%);
             border: 2px solid rgba(255, 255, 255, 0.35);
             box-shadow: 0 10px 40px rgba(41, 161, 196, 0.35);
-            justify-content: flex-start;
-            align-items: stretch;
-            padding: 14px 14px 46px;
+            padding: 12px 12px 44px;
         }
 
         .bubble.stretch-bubble:hover:not(.dragging) {
@@ -199,10 +201,10 @@
         .stretch-timer {
             display: flex;
             flex-direction: column;
-            gap: 10px;
+            gap: 8px;
             width: 100%;
             color: #ffffff;
-            padding-bottom: 8px;
+            flex: 1;
         }
 
         .stretch-header {
@@ -212,19 +214,14 @@
         }
 
         .stretch-title {
-            font-size: 1rem;
+            font-size: 0.95rem;
             font-weight: 600;
-            letter-spacing: 0.5px;
-        }
-
-        .stretch-description {
-            font-size: 0.7rem;
-            opacity: 0.8;
+            letter-spacing: 0.4px;
         }
 
         .stretch-inputs {
             display: flex;
-            gap: 8px;
+            gap: 6px;
             width: 100%;
             flex-wrap: nowrap;
         }
@@ -232,25 +229,27 @@
         .stretch-field {
             display: flex;
             flex-direction: column;
-            gap: 3px;
-            font-size: 0.72rem;
+            gap: 2px;
             text-transform: uppercase;
-            letter-spacing: 0.5px;
+            letter-spacing: 0.35px;
             flex: 1 1 0;
             min-width: 0;
+            font-size: 0.68rem;
         }
 
         .stretch-field span {
             font-weight: 600;
             color: #ffffff;
+            font-size: 0.68rem;
+            letter-spacing: 0.35px;
         }
 
         .stretch-field input {
             width: 100%;
             border: 1px solid rgba(255, 255, 255, 0.35);
-            border-radius: 10px;
-            padding: 6px;
-            font-size: 0.85rem;
+            border-radius: 8px;
+            padding: 5px 6px;
+            font-size: 0.78rem;
             font-weight: 600;
             color: #ffffff;
             background: rgba(15, 32, 60, 0.6);
@@ -268,13 +267,13 @@
         .stretch-timeline {
             display: flex;
             flex-direction: column;
-            gap: 6px;
+            gap: 5px;
         }
 
         .stretch-timeline-line {
             position: relative;
             width: 100%;
-            height: 9px;
+            height: 8px;
             border-radius: 999px;
             background: rgba(255, 255, 255, 0.25);
             overflow: hidden;
@@ -284,8 +283,8 @@
         .stretch-timeline-pointer {
             position: absolute;
             top: 50%;
-            width: 12px;
-            height: 12px;
+            width: 10px;
+            height: 10px;
             border-radius: 50%;
             background: #ffffff;
             border: 2px solid rgba(31, 59, 115, 0.4);
@@ -295,10 +294,10 @@
         }
 
         .stretch-status {
-            font-size: 0.78rem;
+            font-size: 0.72rem;
             font-weight: 600;
             text-align: center;
-            padding: 6px 8px;
+            padding: 5px 6px;
             border-radius: 999px;
             background: rgba(15, 32, 60, 0.45);
             box-shadow: inset 0 1px 3px rgba(15, 23, 42, 0.3);
@@ -306,25 +305,30 @@
 
         .stretch-controls {
             display: flex;
-            gap: 8px;
+            gap: 6px;
+            justify-content: center;
         }
 
         .stretch-btn {
-            flex: 1;
-            padding: 6px 0;
+            width: 38px;
+            height: 38px;
             border: 1px solid rgba(255, 255, 255, 0.35);
-            border-radius: 999px;
+            border-radius: 50%;
             font-weight: 600;
-            font-size: 0.85rem;
+            font-size: 1.05rem;
+            line-height: 1;
             cursor: pointer;
             background: rgba(15, 32, 60, 0.65);
             color: #ffffff;
             box-shadow: 0 4px 12px rgba(15, 23, 42, 0.25);
             transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
         }
 
         .stretch-btn:hover {
-            transform: translateY(-2px);
+            transform: translateY(-1px);
             box-shadow: 0 6px 14px rgba(15, 23, 42, 0.3);
             background: rgba(22, 46, 88, 0.75);
         }
@@ -360,11 +364,12 @@
 
         .converter {
             width: 100%;
-            padding: 15px;
+            padding: 0;
             display: flex;
             flex-direction: column;
-            gap: 12px;
+            gap: 10px;
             color: #ffffff;
+            flex: 1;
         }
 
         .converter-header {
@@ -377,9 +382,10 @@
         }
 
         .converter-title {
-            font-size: 1rem;
+            font-size: 0.92rem;
             font-weight: 600;
             color: #ffffff;
+            letter-spacing: 0.2px;
         }
 
         .swap-btn {
@@ -408,10 +414,10 @@
 
         .input-group select {
             flex: 1;
-            padding: 6px 8px;
+            padding: 5px 6px;
             border: 1px solid rgba(255, 255, 255, 0.35);
             border-radius: 4px;
-            font-size: 0.9rem;
+            font-size: 0.82rem;
             background: rgba(17, 34, 68, 0.65);
             color: #ffffff;
             cursor: pointer;
@@ -424,10 +430,10 @@
 
         .input-group input {
             flex: 1;
-            padding: 6px 8px;
+            padding: 5px 6px;
             border: 1px solid rgba(255, 255, 255, 0.35);
             border-radius: 4px;
-            font-size: 0.9rem;
+            font-size: 0.82rem;
             background: rgba(17, 34, 68, 0.65);
             color: #ffffff;
         }
@@ -442,10 +448,11 @@
         }
 
         .input-label {
-            font-size: 0.9rem;
+            font-size: 0.68rem;
             font-weight: 500;
             color: #ffffff;
-            min-width: 15px;
+            min-width: 14px;
+            letter-spacing: 0.35px;
         }
 
         .results {
@@ -461,24 +468,26 @@
         }
 
         .result-label {
-            font-size: 0.8rem;
+            font-size: 0.72rem;
             color: #ffffff;
             font-weight: 500;
+            letter-spacing: 0.3px;
         }
 
         .result-value {
-            font-size: 0.8rem;
+            font-size: 0.74rem;
             font-weight: 600;
             color: #ffffff;
         }
 
         .word {
-            font-size: 1.2rem;
+            font-size: 1.1rem;
             font-weight: 600;
             color: #ffffff;
             text-align: center;
             padding: 10px;
             text-transform: capitalize;
+            margin: auto;
         }
 
         .title {
@@ -495,19 +504,24 @@
 
         /* Mobile responsiveness */
         @media (max-width: 768px) {
+            body {
+                padding: 12px;
+                align-items: flex-start;
+            }
+
             .grid {
                 grid-template-columns: 1fr;
-                grid-template-rows: repeat(12, 1fr);
-                min-height: auto;
-                gap: 15px;
+                gap: 12px;
+                max-width: 100%;
             }
 
             .bubble {
-                min-height: 80px;
+                padding: 10px 10px 36px;
+                min-height: 0;
             }
 
             .bubble.stretch-bubble {
-                padding: 16px 16px 52px;
+                padding: 10px 10px 36px;
             }
 
             .word {
@@ -524,15 +538,23 @@
 
             .title {
                 font-size: 2rem;
-                margin-bottom: 30px;
-            }
-
-            body {
-                padding: 15px;
+                margin-bottom: 24px;
             }
         }
 
         @media (max-width: 480px) {
+            body {
+                padding: 10px;
+            }
+
+            .grid {
+                gap: 10px;
+            }
+
+            .bubble {
+                padding: 8px 8px 30px;
+            }
+
             .title {
                 font-size: 1.5rem;
             }
@@ -1201,7 +1223,6 @@
                 <div class="stretch-timer">
                     <div class="stretch-header">
                         <span class="stretch-title">Stretch Stopwatch</span>
-                        <span class="stretch-description">Customize your stretching and rest intervals</span>
                     </div>
                     <div class="stretch-inputs">
                         <label class="stretch-field">
@@ -1224,8 +1245,8 @@
                     </div>
                     <div class="stretch-status" id="stretchStatus">Ready to stretch</div>
                     <div class="stretch-controls">
-                        <button class="stretch-btn" id="stretchStartPause">Start</button>
-                        <button class="stretch-btn" id="stretchRestart">Restart</button>
+                        <button class="stretch-btn" id="stretchStartPause" type="button" aria-label="Start">▶</button>
+                        <button class="stretch-btn" id="stretchRestart" type="button" aria-label="Restart">↺</button>
                     </div>
                 </div>
             `;
@@ -1238,6 +1259,26 @@
             const statusDisplay = bubble.querySelector('#stretchStatus');
             const startPauseButton = bubble.querySelector('#stretchStartPause');
             const restartButton = bubble.querySelector('#stretchRestart');
+
+            const START_ICON = '▶';
+            const PAUSE_ICON = '⏸';
+            const RESTART_ICON = '↺';
+
+            function setStartButtonState(state) {
+                if (state === 'pause') {
+                    startPauseButton.textContent = PAUSE_ICON;
+                    startPauseButton.setAttribute('aria-label', 'Pause');
+                } else if (state === 'resume') {
+                    startPauseButton.textContent = START_ICON;
+                    startPauseButton.setAttribute('aria-label', 'Resume');
+                } else {
+                    startPauseButton.textContent = START_ICON;
+                    startPauseButton.setAttribute('aria-label', 'Start');
+                }
+            }
+
+            restartButton.textContent = RESTART_ICON;
+            restartButton.setAttribute('aria-label', 'Restart');
 
             let timerState = 'idle';
             let phases = [];
@@ -1380,7 +1421,7 @@
                     statusDisplay.textContent = workoutTotal > 0 ? defaultReadyMessage : 'Add time and sets to begin';
                 }
 
-                startPauseButton.textContent = 'Start';
+                setStartButtonState('start');
             }
 
             function formatTime(seconds) {
@@ -1555,7 +1596,7 @@
                 elapsedWorkoutTime = workoutTotal;
                 updatePointer();
                 statusDisplay.textContent = 'All stretches complete! Great job!';
-                startPauseButton.textContent = 'Start';
+                setStartButtonState('start');
             }
 
             function progress(delta) {
@@ -1635,13 +1676,13 @@
                     updatePointer();
                     statusDisplay.textContent = 'Set at least one stretch longer than 0 seconds to begin.';
                     timerState = 'idle';
-                    startPauseButton.textContent = 'Start';
+                    setStartButtonState('start');
                     return;
                 }
 
                 stopAnimationFrame();
                 timerState = 'running';
-                startPauseButton.textContent = 'Pause';
+                setStartButtonState('pause');
                 currentPhaseIndex = -1;
                 phaseRemaining = 0;
                 elapsedWorkoutTime = 0;
@@ -1661,7 +1702,7 @@
                 timerState = 'paused';
                 const label = buildPhaseLabel();
                 statusDisplay.textContent = label ? `Paused – ${label}` : 'Paused';
-                startPauseButton.textContent = 'Resume';
+                setStartButtonState('resume');
             }
 
             function resumeTimer() {
@@ -1670,7 +1711,7 @@
                 }
 
                 timerState = 'running';
-                startPauseButton.textContent = 'Pause';
+                setStartButtonState('pause');
                 lastTimestamp = null;
                 updateStatusDuringPhase();
                 animationFrameId = requestAnimationFrame(step);


### PR DESCRIPTION
## Summary
- enforce square bubbles across the grid by constraining the grid width and bubble aspect ratio while tightening converter spacing
- shrink explanatory labels and input controls so every converter uses the same compact typography, improving fit on desktop and mobile
- update the stretch timer to remove the subtitle and replace the Start/Restart buttons with icon-only controls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce08a74df083339aadff19a8bda932